### PR TITLE
[spilled object push optimization 3/3] Object manager Push from Spilled Object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -206,8 +206,8 @@ Ray Serve Quick Start
 - Framework Agnostic: Use the same toolkit to serve everything from deep
   learning models built with frameworks like PyTorch or Tensorflow & Keras
   to Scikit-Learn models or arbitrary business logic.
-- Python First: Configure your model serving with pure Python code - no more
-  YAMLs or JSON configs.
+- Python First: Configure your model serving declaratively in pure Python,
+  without needing YAMLs or JSON configs.
 - Performance Oriented: Turn on batching, pipelining, and GPU acceleration to
   increase the throughput of your model.
 - Composition Native: Allow you to create "model pipelines" by composing multiple

--- a/doc/source/serve/index.rst
+++ b/doc/source/serve/index.rst
@@ -25,8 +25,7 @@ Ray Serve is an easy-to-use scalable model serving library built on Ray.  Ray Se
 - **Framework-agnostic**: Use a single toolkit to serve everything from deep learning models
   built with frameworks like :ref:`PyTorch <serve-pytorch-tutorial>`,
   :ref:`Tensorflow, and Keras <serve-tensorflow-tutorial>`, to :ref:`Scikit-Learn <serve-sklearn-tutorial>` models, to arbitrary Python business logic.
-- **Python-first**: Configure your model serving with pure Python code---no more YAML or
-  JSON configs.
+- **Python-first**: Configure your model serving declaratively in pure Python, without needing YAML or JSON configs.
 
 Since Ray Serve is built on Ray, it allows you to easily scale to many machines, both in your datacenter and in the cloud.
 

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -29,9 +29,9 @@ ObjectStoreRunner::ObjectStoreRunner(const ObjectManagerConfig &config,
                                      std::function<void()> object_store_full_callback,
                                      AddObjectCallback add_object_callback,
                                      DeleteObjectCallback delete_object_callback) {
-  plasma::plasma_store_runner.reset(
-      new plasma::PlasmaStoreRunner(config.store_socket_name, config.object_store_memory,
-                                    config.huge_pages, config.plasma_directory));
+  plasma::plasma_store_runner.reset(new plasma::PlasmaStoreRunner(
+      config.store_socket_name, config.object_store_memory, config.huge_pages,
+      config.plasma_directory, config.fallback_directory));
   // Initialize object store.
   store_thread_ =
       std::thread(&plasma::PlasmaStoreRunner::Start, plasma::plasma_store_runner.get(),

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -332,95 +332,130 @@ void ObjectManager::HandleReceiveFinished(const ObjectID &object_id,
 void ObjectManager::Push(const ObjectID &object_id, const NodeID &node_id) {
   RAY_LOG(DEBUG) << "Push on " << self_node_id_ << " to " << node_id << " of object "
                  << object_id;
-  if (local_objects_.count(object_id) == 0) {
-    // Avoid setting duplicated timer for the same object and node pair.
-    auto &nodes = unfulfilled_push_requests_[object_id];
-    // Issue a restore request if the object is on local disk. This is only relevant
-    // if the local filesystem storage type is being used.
-    auto object_url = get_spilled_object_url_(object_id);
-    if (!object_url.empty()) {
-      restore_spilled_object_(object_id, object_url, nullptr);
-    }
-    if (nodes.count(node_id) == 0) {
-      // If config_.push_timeout_ms < 0, we give an empty timer
-      // and the task will be kept infinitely.
-      std::unique_ptr<boost::asio::deadline_timer> timer;
-      if (config_.push_timeout_ms == 0) {
-        // The Push request fails directly when config_.push_timeout_ms == 0.
-        RAY_LOG(WARNING) << "Invalid Push request ObjectID " << object_id
-                         << " due to direct timeout setting. (0 ms timeout)";
-      } else if (config_.push_timeout_ms > 0) {
-        // Put the task into a queue and wait for the notification of Object added.
-        timer.reset(new boost::asio::deadline_timer(*main_service_));
-        auto clean_push_period = boost::posix_time::milliseconds(config_.push_timeout_ms);
-        timer->expires_from_now(clean_push_period);
-        timer->async_wait(
-            [this, object_id, node_id](const boost::system::error_code &error) {
-              // Timer killing will receive the boost::asio::error::operation_aborted,
-              // we only handle the timeout event.
-              if (!error) {
-                HandlePushTaskTimeout(object_id, node_id);
-              }
-            });
-      }
-      if (config_.push_timeout_ms != 0) {
-        nodes.emplace(node_id, std::move(timer));
-      }
-    }
-    return;
+  if (local_objects_.count(object_id) != 0) {
+    return PushLocalObject(object_id, node_id);
   }
 
-  auto rpc_client = GetRpcClient(node_id);
-  if (rpc_client) {
-    const ObjectInfo &object_info = local_objects_[object_id].object_info;
-    uint64_t data_size =
-        static_cast<uint64_t>(object_info.data_size + object_info.metadata_size);
-    uint64_t metadata_size = static_cast<uint64_t>(object_info.metadata_size);
-    uint64_t num_chunks = buffer_pool_.GetNumChunks(data_size);
-
-    rpc::Address owner_address;
-    owner_address.set_raylet_id(object_info.owner_raylet_id.Binary());
-    owner_address.set_ip_address(object_info.owner_ip_address);
-    owner_address.set_port(object_info.owner_port);
-    owner_address.set_worker_id(object_info.owner_worker_id.Binary());
-
-    RAY_LOG(DEBUG) << "Sending object chunks of " << object_id << " to node " << node_id
-                   << ", number of chunks: " << num_chunks
-                   << ", total data size: " << data_size;
-
-    UniqueID push_id = UniqueID::FromRandom();
-    push_manager_->StartPush(node_id, object_id, num_chunks, [=](int64_t chunk_id) {
-      rpc_service_.post(
-          [=]() {
-            // Post to the multithreaded RPC event loop so that data is copied
-            // off of the main thread.
-            SendObjectChunk(push_id, object_id, owner_address, node_id, data_size,
-                            metadata_size, chunk_id, rpc_client,
-                            [=](const Status &status) {
-                              // Post back to the main event loop because the
-                              // PushManager is thread-safe.
-                              main_service_->post(
-                                  [this, node_id, object_id]() {
-                                    push_manager_->OnChunkComplete(node_id, object_id);
-                                  },
-                                  "ObjectManager.Push");
-                            });
-          },
-          "ObjectManager.Push");
-    });
-  } else {
-    // Push is best effort, so do nothing here.
-    RAY_LOG(ERROR)
-        << "Failed to establish connection for Push with remote object manager.";
+  // Avoid setting duplicated timer for the same object and node pair.
+  auto &nodes = unfulfilled_push_requests_[object_id];
+  // Issue a restore request if the object is on local disk. This is only relevant
+  // if the local filesystem storage type is being used.
+  auto object_url = get_spilled_object_url_(object_id);
+  if (!object_url.empty()) {
+    restore_spilled_object_(object_id, object_url, nullptr);
+  }
+  if (nodes.count(node_id) == 0) {
+    // If config_.push_timeout_ms < 0, we give an empty timer
+    // and the task will be kept infinitely.
+    std::unique_ptr<boost::asio::deadline_timer> timer;
+    if (config_.push_timeout_ms == 0) {
+      // The Push request fails directly when config_.push_timeout_ms == 0.
+      RAY_LOG(WARNING) << "Invalid Push request ObjectID " << object_id
+                       << " due to direct timeout setting. (0 ms timeout)";
+    } else if (config_.push_timeout_ms > 0) {
+      // Put the task into a queue and wait for the notification of Object added.
+      timer.reset(new boost::asio::deadline_timer(*main_service_));
+      auto clean_push_period = boost::posix_time::milliseconds(config_.push_timeout_ms);
+      timer->expires_from_now(clean_push_period);
+      timer->async_wait(
+          [this, object_id, node_id](const boost::system::error_code &error) {
+            // Timer killing will receive the boost::asio::error::operation_aborted,
+            // we only handle the timeout event.
+            if (!error) {
+              HandlePushTaskTimeout(object_id, node_id);
+            }
+          });
+    }
+    if (config_.push_timeout_ms != 0) {
+      nodes.emplace(node_id, std::move(timer));
+    }
   }
 }
 
-void ObjectManager::SendObjectChunk(const UniqueID &push_id, const ObjectID &object_id,
-                                    const rpc::Address &owner_address,
-                                    const NodeID &node_id, uint64_t data_size,
-                                    uint64_t metadata_size, uint64_t chunk_index,
-                                    std::shared_ptr<rpc::ObjectManagerClient> rpc_client,
-                                    std::function<void(const Status &)> on_complete) {
+void ObjectManager::PushLocalObject(const ObjectID &object_id, const NodeID &node_id) {
+  const ObjectInfo &object_info = local_objects_[object_id].object_info;
+  uint64_t total_data_size =
+      static_cast<uint64_t>(object_info.data_size + object_info.metadata_size);
+  uint64_t metadata_size = static_cast<uint64_t>(object_info.metadata_size);
+  uint64_t num_chunks = buffer_pool_.GetNumChunks(total_data_size);
+
+  rpc::Address owner_address;
+  owner_address.set_raylet_id(object_info.owner_raylet_id.Binary());
+  owner_address.set_ip_address(object_info.owner_ip_address);
+  owner_address.set_port(object_info.owner_port);
+  owner_address.set_worker_id(object_info.owner_worker_id.Binary());
+
+  auto local_chunk_reader = [this, object_id, total_data_size, metadata_size](
+                                uint64_t chunk_index,
+                                rpc::PushRequest &push_request) -> Status {
+    std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> chunk_status =
+        buffer_pool_.GetChunk(object_id, total_data_size, metadata_size, chunk_index);
+    // Fail on status not okay. The object is local, and there is
+    // no other anticipated error here.
+    Status status = chunk_status.second;
+    if (status.ok()) {
+      ObjectBufferPool::ChunkInfo chunk_info = chunk_status.first;
+      push_request.set_data(chunk_info.data, chunk_info.buffer_length);
+    }
+    return status;
+  };
+
+  auto release_chunk_callback = [this, object_id](uint64_t chunk_index) {
+    buffer_pool_.ReleaseGetChunk(object_id, chunk_index);
+  };
+
+  PushObjectInternal(object_id, node_id, total_data_size, metadata_size, num_chunks,
+                     std::move(owner_address), std::move(local_chunk_reader),
+                     std::move(release_chunk_callback));
+}
+
+void ObjectManager::PushObjectInternal(
+    const ObjectID &object_id, const NodeID &node_id, uint64_t total_data_size,
+    uint64_t metadata_size, uint64_t num_chunks, rpc::Address owner_address,
+    std::function<ray::Status(uint64_t, rpc::PushRequest &)> chunk_reader,
+    std::function<void(uint64_t)> release_chunk_callback) {
+  auto rpc_client = GetRpcClient(node_id);
+  if (!rpc_client) {
+    // Push is best effort, so do nothing here.
+    RAY_LOG(ERROR)
+        << "Failed to establish connection for Push with remote object manager.";
+    return;
+  }
+
+  RAY_LOG(DEBUG) << "Sending object chunks of " << object_id << " to node " << node_id
+                 << ", number of chunks: " << num_chunks
+                 << ", total data size: " << total_data_size;
+
+  auto push_id = UniqueID::FromRandom();
+  push_manager_->StartPush(node_id, object_id, num_chunks, [=](int64_t chunk_id) {
+    rpc_service_.post(
+        [=]() {
+          // Post to the multithreaded RPC event loop so that data is copied
+          // off of the main thread.
+          SendObjectChunk(push_id, object_id, owner_address, node_id, total_data_size,
+                          metadata_size, chunk_id, rpc_client,
+                          [=](const Status &status) {
+                            // Post back to the main event loop because the
+                            // PushManager is thread-safe.
+                            main_service_->post(
+                                [this, node_id, object_id]() {
+                                  push_manager_->OnChunkComplete(node_id, object_id);
+                                },
+                                "ObjectManager.Push");
+                          },
+                          std::move(chunk_reader), std::move(release_chunk_callback));
+        },
+        "ObjectManager.Push");
+  });
+}
+
+void ObjectManager::SendObjectChunk(
+    const UniqueID &push_id, const ObjectID &object_id, const rpc::Address &owner_address,
+    const NodeID &node_id, uint64_t total_data_size, uint64_t metadata_size,
+    uint64_t chunk_index, std::shared_ptr<rpc::ObjectManagerClient> rpc_client,
+    std::function<void(const Status &)> on_complete,
+    std::function<ray::Status(uint64_t, rpc::PushRequest &)> chunk_reader,
+    std::function<void(uint64_t)> release_chunk_callback) {
   double start_time = absl::GetCurrentTimeNanos() / 1e9;
   rpc::PushRequest push_request;
   // Set request header
@@ -428,26 +463,18 @@ void ObjectManager::SendObjectChunk(const UniqueID &push_id, const ObjectID &obj
   push_request.set_object_id(object_id.Binary());
   push_request.mutable_owner_address()->CopyFrom(owner_address);
   push_request.set_node_id(self_node_id_.Binary());
-  push_request.set_data_size(data_size);
+  push_request.set_data_size(total_data_size);
   push_request.set_metadata_size(metadata_size);
   push_request.set_chunk_index(chunk_index);
 
-  // Get data
-  std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> chunk_status =
-      buffer_pool_.GetChunk(object_id, data_size, metadata_size, chunk_index);
-  ObjectBufferPool::ChunkInfo chunk_info = chunk_status.first;
-
-  // Fail on status not okay. The object is local, and there is
-  // no other anticipated error here.
-  ray::Status status = chunk_status.second;
-  if (!chunk_status.second.ok()) {
+  // read a chunk into push_request and handle errors.
+  auto status = chunk_reader(chunk_index, push_request);
+  if (!status.ok()) {
     RAY_LOG(WARNING) << "Attempting to push object " << object_id
                      << " which is not local. It may have been evicted.";
     on_complete(status);
     return;
   }
-
-  push_request.set_data(chunk_info.data, chunk_info.buffer_length);
 
   // record the time cost between send chunk and receive reply
   rpc::ClientCallback<rpc::PushReply> callback =
@@ -463,10 +490,10 @@ void ObjectManager::SendObjectChunk(const UniqueID &push_id, const ObjectID &obj
         HandleSendFinished(object_id, node_id, chunk_index, start_time, end_time, status);
         on_complete(status);
       };
+
   rpc_client->Push(push_request, callback);
 
-  // Do this regardless of whether it failed or succeeded.
-  buffer_pool_.ReleaseGetChunk(object_id, chunk_info.chunk_index);
+  release_chunk_callback(chunk_index);
 }
 
 ray::Status ObjectManager::Wait(

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -75,6 +75,8 @@ struct ObjectManagerConfig {
   int64_t object_store_memory = -1;
   /// The directory for shared memory files.
   std::string plasma_directory;
+  /// The directory for fallback allocation files.
+  std::string fallback_directory;
   /// Enable huge pages.
   bool huge_pages;
 };

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -40,6 +40,7 @@
 #include "ray/object_manager/plasma/store_runner.h"
 #include "ray/object_manager/pull_manager.h"
 #include "ray/object_manager/push_manager.h"
+#include "ray/object_manager/spilled_object.h"
 #include "ray/rpc/object_manager/object_manager_client.h"
 #include "ray/rpc/object_manager/object_manager_server.h"
 #include "src/ray/protobuf/common.pb.h"
@@ -359,6 +360,14 @@ class ObjectManager : public ObjectManagerInterface,
   /// \param node_id The remote node's id.
   /// \return Void.
   void PushLocalObject(const ObjectID &object_id, const NodeID &node_id);
+
+  /// Pushing a known spilled object to a remote object manager.
+  /// \param object_id The object's object id.
+  /// \param node_id The remote node's id.
+  /// \param spilled_url The url of the spilled object.
+  /// \return Void.
+  void PushSpilledObject(const ObjectID &object_id, const NodeID &node_id,
+                         const std::string &spilled_url);
 
   /// The internal implementation of pushing an object.
   ///

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -144,25 +144,6 @@ class ObjectManager : public ObjectManagerInterface,
                          rpc::FreeObjectsReply *reply,
                          rpc::SendReplyCallback send_reply_callback) override;
 
-  /// Send object to remote object manager
-  ///
-  /// Object will be transfered as a sequence of chunks, small object(defined in config)
-  /// contains only one chunk
-  /// \param push_id Unique push id to indicate this push request
-  /// \param object_id Object id
-  /// \param owner_address The address of the object's owner
-  /// \param node_id The id of the receiver.
-  /// \param data_size Data size
-  /// \param metadata_size Metadata size
-  /// \param chunk_index Chunk index of this object chunk, start with 0
-  /// \param rpc_client Rpc client used to send message to remote object manager
-  /// \param on_complete Callback to run on completion.
-  void SendObjectChunk(const UniqueID &push_id, const ObjectID &object_id,
-                       const rpc::Address &owner_address, const NodeID &node_id,
-                       uint64_t data_size, uint64_t metadata_size, uint64_t chunk_index,
-                       std::shared_ptr<rpc::ObjectManagerClient> rpc_client,
-                       std::function<void(const Status &)> on_complete);
-
   /// Receive an object chunk from a remote object manager. Small object may
   /// fit in one chunk.
   ///
@@ -371,6 +352,51 @@ class ObjectManager : public ObjectManagerInterface,
   void SpreadFreeObjectsRequest(
       const std::vector<ObjectID> &object_ids,
       const std::vector<std::shared_ptr<rpc::ObjectManagerClient>> &rpc_clients);
+
+  /// Pushing a known local object to a remote object manager.
+  ///
+  /// \param object_id The object's object id.
+  /// \param node_id The remote node's id.
+  /// \return Void.
+  void PushLocalObject(const ObjectID &object_id, const NodeID &node_id);
+
+  /// The internal implementation of pushing an object.
+  ///
+  /// \param chunk_reader Read the chunk into push_request's data fields; return
+  /// Status::OK() if the read succeeded.
+  /// \param release_chunk_callback Notify that a chunk is no longer needed.
+  void PushObjectInternal(
+      const ObjectID &object_id, const NodeID &node_id, uint64_t total_data_size,
+      uint64_t metadata_size, uint64_t num_chunks, rpc::Address owner_address,
+      std::function<ray::Status(uint64_t, rpc::PushRequest &)> chunk_reader,
+      std::function<void(uint64_t)> release_chunk_callback);
+
+  /// Send one chunk of the object to remote object manager
+  ///
+  /// Object will be transfered as a sequence of chunks, small object(defined in config)
+  /// contains only one chunk
+  /// \param push_id Unique push id to indicate this push request
+  /// \param object_id Object id
+  /// \param owner_address The address of the object's owner
+  /// \param node_id The id of the receiver.
+  /// \param data_size Data size
+  /// \param metadata_size Metadata size
+  /// \param chunk_index Chunk index of this object chunk, start with 0
+  /// \param rpc_client Rpc client used to send message to remote object manager
+  /// \param chunk_reader Read the chunk into push_request's data fields; return
+  /// Status::OK() if the read succeeded.
+  /// \param release_chunk_callback Notify that a chunk is no longer needed.
+  /// \param on_complete Callback to run on completion.
+  void SendObjectChunk(
+      const UniqueID &push_id, const ObjectID &object_id,
+      const rpc::Address &owner_address, const NodeID &node_id, uint64_t total_data_size,
+      uint64_t metadata_size, uint64_t chunk_index,
+      std::shared_ptr<rpc::ObjectManagerClient> rpc_client,
+      std::function<void(const Status &)> on_complete,
+      std::function<ray::Status(/*chunk_index*/ uint64_t,
+                                /*push_request*/ rpc::PushRequest &)>
+          chunk_reader,
+      std::function<void(/*chunk_index*/ uint64_t)> release_chunk_callback);
 
   /// Handle starting, running, and stopping asio rpc_service.
   void StartRpcService();

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -99,8 +99,7 @@ void create_and_mmap_buffer(int64_t size, void **pointer, int *fd) {
   // allocations will be run with dlmallopt(M_MMAP_THRESHOLD, 0) set by
   // plasma_allocator.cc.
   if (allocated_once && RayConfig::instance().plasma_unlimited()) {
-    // TODO(ekl) get this from the node manager config.
-    file_template = "/tmp";
+    file_template = plasma_config->fallback_directory;
   }
 
   file_template += "/plasmaXXXXXX";

--- a/src/ray/object_manager/plasma/plasma.h
+++ b/src/ray/object_manager/plasma/plasma.h
@@ -76,6 +76,9 @@ struct PlasmaStoreInfo {
   bool hugepages_enabled;
   /// A (platform-dependent) directory where to create the memory-backed file.
   std::string directory;
+  /// A (platform-dependent) directory where to create fallback files. This
+  /// should NOT be in /dev/shm.
+  std::string fallback_directory;
 };
 
 /// Get an entry from the object table and return NULL if the object_id

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -131,8 +131,8 @@ GetRequest::GetRequest(instrumented_io_context &io_context,
 }
 
 PlasmaStore::PlasmaStore(instrumented_io_context &main_service, std::string directory,
-                         bool hugepages_enabled, const std::string &socket_name,
-                         uint32_t delay_on_oom_ms,
+                         std::string fallback_directory, bool hugepages_enabled,
+                         const std::string &socket_name, uint32_t delay_on_oom_ms,
                          ray::SpillObjectsCallback spill_objects_callback,
                          std::function<void()> object_store_full_callback,
                          ray::AddObjectCallback add_object_callback,
@@ -155,6 +155,7 @@ PlasmaStore::PlasmaStore(instrumented_io_context &main_service, std::string dire
           []() { return absl::GetCurrentTimeNanos(); },
           [this]() { return GetDebugDump(); }) {
   store_info_.directory = directory;
+  store_info_.fallback_directory = fallback_directory;
   store_info_.hugepages_enabled = hugepages_enabled;
   const auto asio_stats_print_interval_ms =
       RayConfig::instance().asio_stats_print_interval_ms();

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -52,8 +52,9 @@ class PlasmaStore {
  public:
   // TODO: PascalCase PlasmaStore methods.
   PlasmaStore(instrumented_io_context &main_service, std::string directory,
-              bool hugepages_enabled, const std::string &socket_name,
-              uint32_t delay_on_oom_ms, ray::SpillObjectsCallback spill_objects_callback,
+              std::string fallback_directory, bool hugepages_enabled,
+              const std::string &socket_name, uint32_t delay_on_oom_ms,
+              ray::SpillObjectsCallback spill_objects_callback,
               std::function<void()> object_store_full_callback,
               ray::AddObjectCallback add_object_callback,
               ray::DeleteObjectCallback delete_object_callback);

--- a/src/ray/object_manager/plasma/store_runner.cc
+++ b/src/ray/object_manager/plasma/store_runner.cc
@@ -14,7 +14,8 @@ namespace plasma {
 void SetMallocGranularity(int value);
 
 PlasmaStoreRunner::PlasmaStoreRunner(std::string socket_name, int64_t system_memory,
-                                     bool hugepages_enabled, std::string plasma_directory)
+                                     bool hugepages_enabled, std::string plasma_directory,
+                                     std::string fallback_directory)
     : hugepages_enabled_(hugepages_enabled) {
   // Sanity check.
   if (socket_name.empty()) {
@@ -39,8 +40,11 @@ PlasmaStoreRunner::PlasmaStoreRunner(std::string socket_name, int64_t system_mem
     plasma_directory = "/tmp";
 #endif
   }
+  if (fallback_directory.empty()) {
+    fallback_directory = "/tmp";
+  }
   RAY_LOG(INFO) << "Starting object store with directory " << plasma_directory
-                << " and huge page support "
+                << ", fallback " << fallback_directory << ", and huge page support "
                 << (hugepages_enabled ? "enabled" : "disabled");
 #ifdef __linux__
   if (!hugepages_enabled) {
@@ -71,6 +75,7 @@ PlasmaStoreRunner::PlasmaStoreRunner(std::string socket_name, int64_t system_mem
 #endif
   system_memory_ = system_memory;
   plasma_directory_ = plasma_directory;
+  fallback_directory_ = fallback_directory;
 }
 
 void PlasmaStoreRunner::Start(ray::SpillObjectsCallback spill_objects_callback,
@@ -81,10 +86,11 @@ void PlasmaStoreRunner::Start(ray::SpillObjectsCallback spill_objects_callback,
   RAY_LOG(DEBUG) << "starting server listening on " << socket_name_;
   {
     absl::MutexLock lock(&store_runner_mutex_);
-    store_.reset(new PlasmaStore(
-        main_service_, plasma_directory_, hugepages_enabled_, socket_name_,
-        RayConfig::instance().object_store_full_delay_ms(), spill_objects_callback,
-        object_store_full_callback, add_object_callback, delete_object_callback));
+    store_.reset(new PlasmaStore(main_service_, plasma_directory_, fallback_directory_,
+                                 hugepages_enabled_, socket_name_,
+                                 RayConfig::instance().object_store_full_delay_ms(),
+                                 spill_objects_callback, object_store_full_callback,
+                                 add_object_callback, delete_object_callback));
     plasma_config = store_->GetPlasmaStoreInfo();
 
     // We are using a single memory-mapped file by mallocing and freeing a single

--- a/src/ray/object_manager/plasma/store_runner.h
+++ b/src/ray/object_manager/plasma/store_runner.h
@@ -12,7 +12,8 @@ namespace plasma {
 class PlasmaStoreRunner {
  public:
   PlasmaStoreRunner(std::string socket_name, int64_t system_memory,
-                    bool hugepages_enabled, std::string plasma_directory);
+                    bool hugepages_enabled, std::string plasma_directory,
+                    std::string fallback_directory);
   void Start(ray::SpillObjectsCallback spill_objects_callback,
              std::function<void()> object_store_full_callback,
              ray::AddObjectCallback add_object_callback,
@@ -35,6 +36,7 @@ class PlasmaStoreRunner {
   int64_t system_memory_;
   bool hugepages_enabled_;
   std::string plasma_directory_;
+  std::string fallback_directory_;
   mutable instrumented_io_context main_service_;
   std::unique_ptr<PlasmaStore> store_;
 };

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -224,6 +224,7 @@ int main(int argc, char *argv[]) {
         object_manager_config.max_bytes_in_flight =
             RayConfig::instance().object_manager_max_bytes_in_flight();
         object_manager_config.plasma_directory = plasma_directory;
+        object_manager_config.fallback_directory = temp_dir;
         object_manager_config.huge_pages = huge_pages;
 
         object_manager_config.rpc_service_threads_number =


### PR DESCRIPTION
This the 3 of 3 PRs that implements spilled object push optimization. Please read #16248 for overall idea.

In this PR, we add a `PushSpilledObject` call which calls to `PushObjectInternal` with SpilledObject chunk reader.

Well, github doesn't quite work well with stacked PRs...

[[pr1](https://github.com/ray-project/ray/pull/16248), [pr2](https://github.com/ray-project/ray/pull/16352), [pr3](https://github.com/scv119/ray/pull/11)] 