### PR TITLE
[Refactor Plasma 2/n] refactor EvictionPolicy 

### DIFF
--- a/src/ray/object_manager/plasma/common.h
+++ b/src/ray/object_manager/plasma/common.h
@@ -45,8 +45,7 @@ enum class ObjectState : int {
   PLASMA_SEALED = 2,
 };
 
-/// This type is used by the Plasma store. It is here because it is exposed to
-/// the eviction policy.
+/// ObjectTableEntry stores the memory allocation information of a Plasma Object.
 struct ObjectTableEntry {
   ObjectTableEntry();
 
@@ -86,7 +85,8 @@ struct ObjectTableEntry {
   plasma::flatbuf::ObjectSource source;
 };
 
-/// Mapping from ObjectIDs to information about the object.
+/// ObjectTable stores the mapping from an ObjectID to its memory allocation infomation
+/// in PlasmaStore.
 typedef std::unordered_map<ObjectID, std::unique_ptr<ObjectTableEntry>> ObjectTable;
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/dlmalloc.cc
+++ b/src/ray/object_manager/plasma/dlmalloc.cc
@@ -231,6 +231,6 @@ bool IsOutsideInitialAllocation(void *p) {
   return (p < initial_region_ptr) || (p >= (initial_region_ptr + initial_region_size));
 }
 
-const PlasmaStoreInfo *plasma_config;
+const PlasmaStoreConfig *plasma_config;
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/eviction_policy.cc
+++ b/src/ray/object_manager/plasma/eviction_policy.cc
@@ -91,9 +91,13 @@ int64_t LRUCache::ChooseObjectsToEvict(int64_t num_bytes_required,
 }
 
 EvictionPolicy::EvictionPolicy(const ObjectTable &object_table, int64_t max_size)
+    : EvictionPolicy(std::make_unique<PlasmaAllocatorAccessor>(object_table), max_size) {}
+
+EvictionPolicy::EvictionPolicy(
+    std::unique_ptr<AllocatorAccessorInterface> allocator_accessor, int64_t max_size)
     : pinned_memory_bytes_(0),
-      object_table_(object_table),
-      cache_("global lru", max_size) {}
+      cache_("global lru", max_size),
+      allocator_accessor_(std::move(allocator_accessor)) {}
 
 int64_t EvictionPolicy::ChooseObjectsToEvict(int64_t num_bytes_required,
                                              std::vector<ObjectID> *objects_to_evict) {
@@ -126,17 +130,17 @@ int64_t EvictionPolicy::RequireSpace(int64_t size,
                                      std::vector<ObjectID> *objects_to_evict) {
   // Check if there is enough space to create the object.
   int64_t required_space =
-      PlasmaAllocator::Allocated() + size - PlasmaAllocator::GetFootprintLimit();
+      allocator_accessor_->GetAllocated() + size - allocator_accessor_->GetCapacity();
   // Try to free up at least as much space as we need right now but ideally
   // up to 20% of the total capacity.
   int64_t space_to_free =
-      std::max(required_space, PlasmaAllocator::GetFootprintLimit() / 5);
+      std::max(required_space, allocator_accessor_->GetCapacity() / 5);
   // Choose some objects to evict, and update the return pointers.
   int64_t num_bytes_evicted = ChooseObjectsToEvict(space_to_free, objects_to_evict);
   RAY_LOG(DEBUG) << "There is not enough space to create this object, so evicting "
                  << objects_to_evict->size() << " objects to free up "
                  << num_bytes_evicted << " bytes. The number of bytes in use (before "
-                 << "this eviction) is " << PlasmaAllocator::Allocated() << ".";
+                 << "this eviction) is " << allocator_accessor_->GetAllocated() << ".";
   return required_space - num_bytes_evicted;
 }
 
@@ -159,10 +163,25 @@ void EvictionPolicy::RemoveObject(const ObjectID &object_id) {
 }
 
 int64_t EvictionPolicy::GetObjectSize(const ObjectID &object_id) const {
+  return allocator_accessor_->GetObjectSize(object_id);
+}
+
+std::string EvictionPolicy::DebugString() const { return cache_.DebugString(); }
+
+PlasmaAllocatorAccessor::PlasmaAllocatorAccessor(const ObjectTable &object_table)
+    : object_table_(object_table) {}
+
+int64_t PlasmaAllocatorAccessor::GetObjectSize(const ObjectID &object_id) const {
   auto entry = GetObjectTableEntry(object_table_, object_id);
   return entry->data_size + entry->metadata_size;
 }
 
-std::string EvictionPolicy::DebugString() const { return cache_.DebugString(); }
+int64_t PlasmaAllocatorAccessor::GetAllocated() const {
+  return PlasmaAllocator::Allocated();
+}
+
+int64_t PlasmaAllocatorAccessor::GetCapacity() const {
+  return PlasmaAllocator::GetFootprintLimit();
+}
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/eviction_policy.cc
+++ b/src/ray/object_manager/plasma/eviction_policy.cc
@@ -90,8 +90,10 @@ int64_t LRUCache::ChooseObjectsToEvict(int64_t num_bytes_required,
   return bytes_evicted;
 }
 
-EvictionPolicy::EvictionPolicy(PlasmaStoreInfo *store_info, int64_t max_size)
-    : pinned_memory_bytes_(0), store_info_(store_info), cache_("global lru", max_size) {}
+EvictionPolicy::EvictionPolicy(const ObjectTable &object_table, int64_t max_size)
+    : pinned_memory_bytes_(0),
+      object_table_(object_table),
+      cache_("global lru", max_size) {}
 
 int64_t EvictionPolicy::ChooseObjectsToEvict(int64_t num_bytes_required,
                                              std::vector<ObjectID> *objects_to_evict) {
@@ -157,7 +159,7 @@ void EvictionPolicy::RemoveObject(const ObjectID &object_id) {
 }
 
 int64_t EvictionPolicy::GetObjectSize(const ObjectID &object_id) const {
-  auto entry = store_info_->objects[object_id].get();
+  auto entry = GetObjectTableEntry(object_table_, object_id);
   return entry->data_size + entry->metadata_size;
 }
 

--- a/src/ray/object_manager/plasma/eviction_policy.h
+++ b/src/ray/object_manager/plasma/eviction_policy.h
@@ -96,10 +96,9 @@ class EvictionPolicy {
  public:
   /// Construct an eviction policy.
   ///
-  /// \param store_info Information about the Plasma store that is exposed
-  ///        to the eviction policy.
+  /// \param object_table Reference to the object_table
   /// \param max_size Max size in bytes total of objects to store.
-  explicit EvictionPolicy(PlasmaStoreInfo *store_info, int64_t max_size);
+  explicit EvictionPolicy(const ObjectTable &object_table, int64_t max_size);
 
   /// Destroy an eviction policy.
   virtual ~EvictionPolicy() {}
@@ -203,8 +202,8 @@ class EvictionPolicy {
   /// The number of bytes pinned by applications.
   int64_t pinned_memory_bytes_;
 
-  /// Pointer to the plasma store info.
-  PlasmaStoreInfo *store_info_;
+  /// A reference to the plasma object table
+  const ObjectTable &object_table_;
   /// Datastructure for the LRU cache.
   LRUCache cache_;
 };

--- a/src/ray/object_manager/plasma/plasma.cc
+++ b/src/ray/object_manager/plasma/plasma.cc
@@ -25,10 +25,10 @@ ObjectTableEntry::ObjectTableEntry() : pointer(nullptr), ref_count(0) {}
 
 ObjectTableEntry::~ObjectTableEntry() { pointer = nullptr; }
 
-ObjectTableEntry *GetObjectTableEntry(PlasmaStoreInfo *store_info,
+ObjectTableEntry *GetObjectTableEntry(const ObjectTable &object_table,
                                       const ObjectID &object_id) {
-  auto it = store_info->objects.find(object_id);
-  if (it == store_info->objects.end()) {
+  auto it = object_table.find(object_id);
+  if (it == object_table.end()) {
     return NULL;
   }
   return it->second.get();

--- a/src/ray/object_manager/plasma/plasma.h
+++ b/src/ray/object_manager/plasma/plasma.h
@@ -65,33 +65,31 @@ enum class ObjectStatus : int {
   OBJECT_FOUND = 1
 };
 
-/// The plasma store information that is exposed to the eviction policy.
-struct PlasmaStoreInfo {
-  /// Objects that are in the Plasma store.
-  ObjectTable objects;
+/// The plasma store config.
+struct PlasmaStoreConfig {
   /// Boolean flag indicating whether to start the object store with hugepages
   /// support enabled. Huge pages are substantially larger than normal memory
   /// pages (e.g. 2MB or 1GB instead of 4KB) and using them can reduce
   /// bookkeeping overhead from the OS.
-  bool hugepages_enabled;
+  const bool hugepages_enabled;
   /// A (platform-dependent) directory where to create the memory-backed file.
-  std::string directory;
+  const std::string directory;
   /// A (platform-dependent) directory where to create fallback files. This
   /// should NOT be in /dev/shm.
-  std::string fallback_directory;
+  const std::string fallback_directory;
 };
 
 /// Get an entry from the object table and return NULL if the object_id
 /// is not present.
 ///
-/// \param store_info The PlasmaStoreInfo that contains the object table.
+/// \param object_table The object table.
 /// \param object_id The object_id of the entry we are looking for.
 /// \return The entry associated with the object_id or NULL if the object_id
 ///         is not present.
-ObjectTableEntry *GetObjectTableEntry(PlasmaStoreInfo *store_info,
+ObjectTableEntry *GetObjectTableEntry(const ObjectTable &object_table,
                                       const ObjectID &object_id);
 
 /// Globally accessible reference to plasma store configuration.
-extern const PlasmaStoreInfo *plasma_config;
+extern const PlasmaStoreConfig *plasma_config;
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/quota_aware_policy.cc
+++ b/src/ray/object_manager/plasma/quota_aware_policy.cc
@@ -26,8 +26,8 @@
 
 namespace plasma {
 
-QuotaAwarePolicy::QuotaAwarePolicy(PlasmaStoreInfo *store_info, int64_t max_size)
-    : EvictionPolicy(store_info, max_size) {}
+QuotaAwarePolicy::QuotaAwarePolicy(const ObjectTable &object_table, int64_t max_size)
+    : EvictionPolicy(object_table, max_size) {}
 
 bool QuotaAwarePolicy::HasQuota(Client *client, bool is_create) {
   if (!is_create) {

--- a/src/ray/object_manager/plasma/quota_aware_policy.h
+++ b/src/ray/object_manager/plasma/quota_aware_policy.h
@@ -56,10 +56,9 @@ class QuotaAwarePolicy : public EvictionPolicy {
  public:
   /// Construct a quota-aware eviction policy.
   ///
-  /// \param store_info Information about the Plasma store that is exposed
-  ///        to the eviction policy.
+  /// \param object_table Reference to the plasma store object table.
   /// \param max_size Max size in bytes total of objects to store.
-  explicit QuotaAwarePolicy(PlasmaStoreInfo *store_info, int64_t max_size);
+  explicit QuotaAwarePolicy(const ObjectTable &object_table, int64_t max_size);
   void ObjectCreated(const ObjectID &object_id, Client *client, bool is_create) override;
   bool SetClientQuota(Client *client, int64_t output_memory_quota) override;
   bool EnforcePerClientQuota(Client *client, int64_t size, bool is_create,

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -143,7 +143,11 @@ PlasmaStore::PlasmaStore(instrumented_io_context &main_service, std::string dire
       socket_name_(socket_name),
       acceptor_(main_service, ParseUrlEndpoint(socket_name)),
       socket_(main_service),
-      eviction_policy_(&store_info_, PlasmaAllocator::GetFootprintLimit()),
+      plasma_config_{.hugepages_enabled = hugepages_enabled,
+                     .directory = directory,
+                     .fallback_directory = fallback_directory},
+      object_table_(),
+      eviction_policy_(object_table_, PlasmaAllocator::GetFootprintLimit()),
       spill_objects_callback_(spill_objects_callback),
       add_object_callback_(add_object_callback),
       delete_object_callback_(delete_object_callback),
@@ -156,9 +160,6 @@ PlasmaStore::PlasmaStore(instrumented_io_context &main_service, std::string dire
           /*get_time=*/
           []() { return absl::GetCurrentTimeNanos(); },
           [this]() { return GetDebugDump(); }) {
-  store_info_.directory = directory;
-  store_info_.fallback_directory = fallback_directory;
-  store_info_.hugepages_enabled = hugepages_enabled;
   const auto event_stats_print_interval_ms =
       RayConfig::instance().event_stats_print_interval_ms();
   if (event_stats_print_interval_ms > 0 && RayConfig::instance().event_stats()) {
@@ -176,7 +177,9 @@ void PlasmaStore::Start() {
 
 void PlasmaStore::Stop() { acceptor_.close(); }
 
-const PlasmaStoreInfo *PlasmaStore::GetPlasmaStoreInfo() { return &store_info_; }
+const PlasmaStoreConfig *PlasmaStore::GetPlasmaStoreConfig() const {
+  return &plasma_config_;
+}
 
 // If this client is not already using the object, add the client to the
 // object's list of clients, otherwise do nothing.
@@ -334,7 +337,7 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID &object_id,
                                       bool fallback_allocator, PlasmaObject *result) {
   RAY_LOG(DEBUG) << "attempting to create object " << object_id << " size " << data_size;
 
-  auto entry = GetObjectTableEntry(&store_info_, object_id);
+  auto entry = GetObjectTableEntry(object_table_, object_id);
   if (entry != nullptr) {
     // There is already an object with the same ID in the Plasma Store, so
     // ignore this request.
@@ -361,7 +364,7 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID &object_id,
 
   RAY_LOG(DEBUG) << "create object " << object_id << " succeeded";
   auto ptr = std::make_unique<ObjectTableEntry>();
-  entry = store_info_.objects.emplace(object_id, std::move(ptr)).first->second.get();
+  entry = object_table_.emplace(object_id, std::move(ptr)).first->second.get();
   entry->data_size = data_size;
   entry->metadata_size = metadata_size;
   entry->pointer = pointer;
@@ -394,7 +397,7 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID &object_id,
   // eviction policy does not have an opportunity to evict the object.
   eviction_policy_.ObjectCreated(object_id, client.get(), true);
   // Record that this client is using this object.
-  AddToClientObjectIds(object_id, store_info_.objects[object_id].get(), client);
+  AddToClientObjectIds(object_id, object_table_[object_id].get(), client);
   num_objects_unsealed_++;
   num_bytes_unsealed_ += data_size + metadata_size;
   num_bytes_created_total_ += data_size + metadata_size;
@@ -517,7 +520,7 @@ void PlasmaStore::UpdateObjectGetRequests(const ObjectID &object_id) {
   size_t num_requests = get_requests.size();
   for (size_t i = 0; i < num_requests; ++i) {
     auto get_req = get_requests[index];
-    auto entry = GetObjectTableEntry(&store_info_, object_id);
+    auto entry = GetObjectTableEntry(object_table_, object_id);
     RAY_CHECK(entry != nullptr);
 
     PlasmaObject_init(&get_req->objects[object_id], entry);
@@ -555,7 +558,7 @@ void PlasmaStore::ProcessGetRequest(const std::shared_ptr<Client> &client,
   for (auto object_id : object_ids) {
     // Check if this object is already present
     // locally. If so, record that the object is being used and mark it as accounted for.
-    auto entry = GetObjectTableEntry(&store_info_, object_id);
+    auto entry = GetObjectTableEntry(object_table_, object_id);
     if (entry && entry->state == ObjectState::PLASMA_SEALED) {
       // Update the get request to take into account the present object.
       PlasmaObject_init(&get_req->objects[object_id], entry);
@@ -624,7 +627,7 @@ int PlasmaStore::RemoveFromClientObjectIds(const ObjectID &object_id,
 }
 
 void PlasmaStore::EraseFromObjectTable(const ObjectID &object_id) {
-  auto &object = store_info_.objects[object_id];
+  auto &object = object_table_[object_id];
   auto buff_size = object->data_size + object->metadata_size;
   if (object->device_num == 0) {
     PlasmaAllocator::Free(object->pointer, buff_size);
@@ -639,12 +642,12 @@ void PlasmaStore::EraseFromObjectTable(const ObjectID &object_id) {
     RAY_LOG(DEBUG) << "Erasing object " << object_id << " with nonzero ref count"
                    << object_id << ", num bytes in use is now " << num_bytes_in_use_;
   }
-  store_info_.objects.erase(object_id);
+  object_table_.erase(object_id);
 }
 
 void PlasmaStore::ReleaseObject(const ObjectID &object_id,
                                 const std::shared_ptr<Client> &client) {
-  auto entry = GetObjectTableEntry(&store_info_, object_id);
+  auto entry = GetObjectTableEntry(object_table_, object_id);
   RAY_CHECK(entry != nullptr);
   // Remove the client from the object's array of clients.
   RAY_CHECK(RemoveFromClientObjectIds(object_id, entry, client) == 1);
@@ -652,7 +655,7 @@ void PlasmaStore::ReleaseObject(const ObjectID &object_id,
 
 // Check if an object is present.
 ObjectStatus PlasmaStore::ContainsObject(const ObjectID &object_id) {
-  auto entry = GetObjectTableEntry(&store_info_, object_id);
+  auto entry = GetObjectTableEntry(object_table_, object_id);
   return entry && entry->state == ObjectState::PLASMA_SEALED
              ? ObjectStatus::OBJECT_FOUND
              : ObjectStatus::OBJECT_NOT_FOUND;
@@ -661,7 +664,7 @@ ObjectStatus PlasmaStore::ContainsObject(const ObjectID &object_id) {
 void PlasmaStore::SealObjects(const std::vector<ObjectID> &object_ids) {
   for (size_t i = 0; i < object_ids.size(); ++i) {
     RAY_LOG(DEBUG) << "sealing object " << object_ids[i];
-    auto entry = GetObjectTableEntry(&store_info_, object_ids[i]);
+    auto entry = GetObjectTableEntry(object_table_, object_ids[i]);
     RAY_CHECK(entry != nullptr);
     RAY_CHECK(entry->state == ObjectState::PLASMA_CREATED);
     // Set the state of object to SEALED.
@@ -690,7 +693,7 @@ void PlasmaStore::SealObjects(const std::vector<ObjectID> &object_ids) {
 
 int PlasmaStore::AbortObject(const ObjectID &object_id,
                              const std::shared_ptr<Client> &client) {
-  auto entry = GetObjectTableEntry(&store_info_, object_id);
+  auto entry = GetObjectTableEntry(object_table_, object_id);
   RAY_CHECK(entry != nullptr) << "To abort an object it must be in the object table.";
   RAY_CHECK(entry->state != ObjectState::PLASMA_SEALED)
       << "To abort an object it must not have been sealed.";
@@ -708,7 +711,7 @@ int PlasmaStore::AbortObject(const ObjectID &object_id,
 }
 
 PlasmaError PlasmaStore::DeleteObject(ObjectID &object_id) {
-  auto entry = GetObjectTableEntry(&store_info_, object_id);
+  auto entry = GetObjectTableEntry(object_table_, object_id);
   // TODO(rkn): This should probably not fail, but should instead throw an
   // error. Maybe we should also support deleting objects that have been
   // created but not sealed.
@@ -741,7 +744,7 @@ PlasmaError PlasmaStore::DeleteObject(ObjectID &object_id) {
 void PlasmaStore::EvictObjects(const std::vector<ObjectID> &object_ids) {
   for (const auto &object_id : object_ids) {
     RAY_LOG(DEBUG) << "evicting object " << object_id.Hex();
-    auto entry = GetObjectTableEntry(&store_info_, object_id);
+    auto entry = GetObjectTableEntry(object_table_, object_id);
     // TODO(rkn): This should probably not fail, but should instead throw an
     // error. Maybe we should also support deleting objects that have been
     // created but not sealed.
@@ -774,8 +777,8 @@ void PlasmaStore::DisconnectClient(const std::shared_ptr<Client> &client) {
   eviction_policy_.ClientDisconnected(client.get());
   std::unordered_map<ObjectID, ObjectTableEntry *> sealed_objects;
   for (const auto &object_id : client->object_ids) {
-    auto it = store_info_.objects.find(object_id);
-    if (it == store_info_.objects.end()) {
+    auto it = object_table_.find(object_id);
+    if (it == object_table_.end()) {
       continue;
     }
 
@@ -993,7 +996,7 @@ bool PlasmaStore::IsObjectSpillable(const ObjectID &object_id) {
   // The lock is acquired when a request is received to the plasma store.
   // recursive mutex is used here to allow
   std::lock_guard<std::recursive_mutex> guard(mutex_);
-  auto entry = GetObjectTableEntry(&store_info_, object_id);
+  auto entry = GetObjectTableEntry(object_table_, object_id);
   return entry->ref_count == 1;
 }
 
@@ -1026,7 +1029,7 @@ std::string PlasmaStore::GetDebugDump() const {
   size_t num_bytes_received = 0;
   size_t num_objects_errored = 0;
   size_t num_bytes_errored = 0;
-  for (const auto &obj_entry : store_info_.objects) {
+  for (const auto &obj_entry : object_table_) {
     const auto &obj = obj_entry.second;
     if (obj->state == ObjectState::PLASMA_CREATED) {
       num_objects_unsealed++;

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -67,8 +67,8 @@ class PlasmaStore {
   /// Stop this store.
   void Stop();
 
-  /// Get a const pointer to the internal PlasmaStoreInfo object.
-  const PlasmaStoreInfo *GetPlasmaStoreInfo();
+  /// Get a const pointer to the internal PlasmaStoreConfig object.
+  const PlasmaStoreConfig *GetPlasmaStoreConfig() const;
 
   /// Create a new object. The client must do a call to release_object to tell
   /// the store when it is done with the object.
@@ -261,10 +261,10 @@ class PlasmaStore {
   boost::asio::basic_socket_acceptor<ray::local_stream_protocol> acceptor_;
   /// The socket to listen on for new clients.
   ray::local_stream_socket socket_;
-
-  /// The plasma store information, including the object tables, that is exposed
-  /// to the eviction policy.
-  PlasmaStoreInfo store_info_;
+  /// The plasma store configs
+  PlasmaStoreConfig plasma_config_;
+  // object tables store all objects in plasma store.
+  ObjectTable object_table_;
   /// The state that is managed by the eviction policy.
   QuotaAwarePolicy eviction_policy_;
   /// A hash table mapping object IDs to a vector of the get requests that are

--- a/src/ray/object_manager/plasma/store_runner.cc
+++ b/src/ray/object_manager/plasma/store_runner.cc
@@ -91,7 +91,7 @@ void PlasmaStoreRunner::Start(ray::SpillObjectsCallback spill_objects_callback,
                                  RayConfig::instance().object_store_full_delay_ms(),
                                  spill_objects_callback, object_store_full_callback,
                                  add_object_callback, delete_object_callback));
-    plasma_config = store_->GetPlasmaStoreInfo();
+    plasma_config = store_->GetPlasmaStoreConfig();
 
     // We are using a single memory-mapped file by mallocing and freeing a single
     // large amount of space up front. According to the documentation,


### PR DESCRIPTION
Refactor EvictionPolicy component so that it doesn't have hard dependency on PlasmaStore/PlasmaStore Allocator.

At a very high level, the EvicitionPolicy components records the (client) access patterns of objects, and make eviction policy based on Allocator's information and allocated object sizes.  Thus it shouldn't be coupled with PlasmaStore.

This change decouples EvicitionPolicy with underlining implementation and make it easier to test.